### PR TITLE
A few improvements / bug fixes

### DIFF
--- a/plugin/varnish-http-purge.php
+++ b/plugin/varnish-http-purge.php
@@ -175,7 +175,7 @@ class VarnishPurger {
         // http://wordpress.org/support/topic/incompatability-with-editorial-calendar-plugin
         wp_remote_request($purgeme, array('method' => 'PURGE', 'headers' => array( 'host' => $p['host'], 'X-Purge-Method' => $varnish_x_purgemethod ) ) );
 
-        do_action('afterPurgeUrl', $url, $purgeme);
+        do_action('after_purge_url', $url, $purgeme);
     }
 
     public function purgePost($postId) {


### PR DESCRIPTION
Hi there. Thanks for the plugin! I noticed a couple issues while using it, and needed to add one new feature for our use case.

Issues:
- Wording "Varnish purge flushed!" should be "Varnish cache purged!" (firejdl/varnish-http-purge@45051a1)
- Whole site was being purged when a page/post is saved, because the 'save_post' action is fired for revisions as well (firejdl/varnish-http-purge@5446921)
- Existing query args were being ignored in the "Purge Varnish" button URL, so you were taken to a different page after purging (firejdl/varnish-http-purge@b6233b3)

Feature:
- Run action hook 'after_purge_url' after purging a url (firejdl/varnish-http-purge@81ac6b9)
