### PR TITLE
Added $postId as parameter to the vhp_purge_urls filter

### DIFF
--- a/plugin/varnish-http-purge.php
+++ b/plugin/varnish-http-purge.php
@@ -249,7 +249,8 @@ class VarnishPurger {
 
         // Filter to add or remove urls to the array of purged urls
         // @param array $purgeUrls the urls (paths) to be purged
-        $this->purgeUrls = apply_filters( 'vhp_purge_urls', $this->purgeUrls );
+        // @param int $postId the id of the new/edited post
+        $this->purgeUrls = apply_filters( 'vhp_purge_urls', $this->purgeUrls, $postId );
 	}
 
 }


### PR DESCRIPTION
Just something quick before this is released.  Added $postId as parameter is really helpful in order to differentiate what extra URLs to add. I just noticed this: Say, the $postId is a product, then purge the shop home too and all upselling products. If it is a blog, do not purge anything related to shop, just the blog stuff. Depending on a users need and what else she/he needs to do, there might be even more use cases. So passing the $postId really helps.

Last commit, I promise ;) and it's only very small improvement.