### PR TITLE
Same name for adminbar and dashboard button

### DIFF
--- a/plugin/varnish-http-purge.php
+++ b/plugin/varnish-http-purge.php
@@ -76,10 +76,10 @@ class VarnishPurger {
 	function varnish_rightnow_adminbar($admin_bar){
 		$admin_bar->add_menu( array(
 			'id'	=> 'purge-varnish-cache-all',
-			'title' => 'Purge Varnish',
+			'title' => 'Purge Varnish Cache',
 			'href'  => wp_nonce_url(add_query_arg('vhp_flush_all', 1), 'varnish-http-purge'),
 			'meta'  => array(
-				'title' => __('Purge Varnish','varnish-http-purge'),
+				'title' => __('Purge your entire Varnish Cache','varnish-http-purge'),
 			),
 		));
 	}


### PR DESCRIPTION
I was puzzled if both buttons really do the same because they are named
differently. I thought the adminbar button might only Purge the
currently visible page (because it's visible next to "Edit page").

Since both buttons do the same (as I learnt from the code) they should
also be name the same way.