### PR TITLE
purge page when comment was approved

### DIFF
--- a/plugin/varnish-http-purge.php
+++ b/plugin/varnish-http-purge.php
@@ -255,9 +255,15 @@ class VarnishPurger {
 
 		// If we made varniship, let it sail
 		if ( isset($varniship) && $varniship != null ) {
-			$purgeme = $schema.$varniship.$path.$pregex;
+			$host = $varniship;
 		} else {
-			$purgeme = $schema.$p['host'].$path.$pregex;
+			$host = $p['host'];
+		}
+
+		$purgeme = $schema.$host.$path.$pregex;
+
+		if (!empty($p['query'])) {
+			$purgeme .= '?' . $p['query'];
 		}
 
 		// Cleanup CURL functions to be wp_remote_request and thus better

--- a/plugin/varnish-http-purge.php
+++ b/plugin/varnish-http-purge.php
@@ -71,6 +71,7 @@ class VarnishPurger {
 				add_action( $event, array($this, 'purgePost'), 10, 2 );
 			}
 		}
+		add_action( 'transition_comment_status', array($this, 'onCommentTransition'), 10, 3 );
 		add_action( 'shutdown', array($this, 'executePurge') );
 
 		// Success: Admin notice when purging
@@ -350,6 +351,22 @@ class VarnishPurger {
         $this->purgeUrls = apply_filters( 'vhp_purge_urls', $this->purgeUrls, $postId );
 	}
 
+	/**
+	 * Comment statuses might be 'trash', 'approved', 'unapproved', 'spam'.
+	 *
+	 * @param int|string $newStatus
+	 * @param int|string $oldStatus
+	 * @param object $comment
+	 */
+	public function onCommentTransition($newStatus, $oldStatus, $comment)
+	{
+		if ($oldStatus == 'unapproved' && $newStatus != 'approved') {
+			// unapproved comment was sent to trash or marked as spam => no need to flush cache
+		} else {
+			// a comment was published or removed => flush cache
+			$this->purgePost($comment->comment_post_ID);
+		}
+	}
 }
 
 $purger = new VarnishPurger();


### PR DESCRIPTION
When a comment status changes, then the respective page should be purged (works in an environment where each comment has to be approved).