### PR TITLE
keep query parameters of $url in purgeUrl

### DIFF
--- a/plugin/varnish-http-purge.php
+++ b/plugin/varnish-http-purge.php
@@ -254,9 +254,15 @@ class VarnishPurger {
 
 		// If we made varniship, let it sail
 		if ( isset($varniship) && $varniship != null ) {
-			$purgeme = $schema.$varniship.$path.$pregex;
+			$host = $varniship;
 		} else {
-			$purgeme = $schema.$p['host'].$path.$pregex;
+			$host = $p['host'];
+		}
+
+		$purgeme = $schema.$host.$path.$pregex;
+
+		if (!empty($p['query'])) {
+			$purgeme .= '?' . $p['query'];
 		}
 
 		// Cleanup CURL functions to be wp_remote_request and thus better


### PR DESCRIPTION
If I add custom URLs via the vhp_purge_urls filter, then these URLs loose their query parameters. This pull request adds them again.