### PR TITLE
do not use query part for purging when using regex

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -260,7 +260,7 @@ class VarnishPurger {
 
 		$purgeme = $schema.$host.$path.$pregex;
 
-		if (!empty($p['query'])) {
+		if (!empty($p['query']) && $p['query'] != 'vhp-regex') {
 			$purgeme .= '?' . $p['query'];
 		}
 


### PR DESCRIPTION
Using the query part for purging is great. Nevertheless I encountered a bug.

When using the regex purge method the query part is set to `'vhp-regex'`. The resulting purge-url is then: `http://somehost.com/.*?vhp-regex`

As a result no page will be purged. Therefore we need to avoid appending this special string.