### PR TITLE
Update purgePost() to validate page_for_posts

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -398,7 +398,10 @@ class VarnishPurger {
 			// Home Page and (if used) posts page
 			array_push($listofurls, home_url('/') );
 			if ( get_option('show_on_front') == 'page' ) {
-				array_push($listofurls, get_permalink( get_option('page_for_posts') ) );
+				// Ensure we have a page_for_posts setting to avoid empty URL
+				if (get_option('page_for_posts')) {
+					array_push($listofurls, get_permalink( get_option('page_for_posts') ) );
+				}
 			}
 		} else {
 			// We're not sure how we got here, but bail instead of processing anything else.


### PR DESCRIPTION
A small patch to fix a relatively-rare use case.

Our bug: Errors in logs when saving a post, caused by varnish-http-purge e.g:

`PHP Notice:  Undefined index: host in /SITE/wp-content/plugins/varnish-http-purge/varnish-http-purge.php on line 292`

These were caused by `purgeUrl()` method being passed empty `$url` arguments. They CAN be solved by validating `$url` at that point:

`
	public function purgeUrl($url) {
		if (!$url)
			return;
`

I won't submit a PR for that, but IMHO something like that would be valuable, especially if it left a log error with a backtrace. What follows took a lot of advanced debugging to figure out. 

I wanted to identify the root cause of the empty $url, and traced it back through `executePurge()` (where the array had an empty item) to `purgePost()`, which added the empty item. 

In the end it was the code that accounts for `show_on_front` that caused the problem for me. The reason is that it assumes that any site with `page` as `get_option('show_on_front')` will ALSO have a value for `get_option('page_for_posts')`. In my case this wasn't true, and the WP UI clearly lets this happen without any warnings (Screenshot: http://i.imgur.com/1uAWA2p.png )

This PR just adds a second validation of `get_option('page_for_posts')` to make sure it exists before adding `get_permalink( get_option('page_for_posts')` into the array of URLs to purge. 

Thanks for merging this ASAP, and considering whether better validation of the URLs from the array would make sense in either `purgeUrl()` or `executePurge()`.

P.S. Not sure what is up with the newline at end of file, tried to fix it sorry about that. 