### PR TITLE
Limit the "Purge Varnish" buttons to admins network admins

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -97,7 +97,7 @@ class VarnishPurger {
 			// Multisite - Network Admin can always purge
 			current_user_can('manage_network') ||
 			// Multisite - Site admins can purge UNLESS it's a subfolder install and we're on site #1
-			( is_multisite() && !current_user_can('manage_network') && ( SUBDOMAIN_INSTALL || ( !SUBDOMAIN_INSTALL && ( BLOG_ID_CURRENT_SITE != $blog_id ) ) ) )
+			( is_multisite() && current_user_can( 'manage_options' ) && ( SUBDOMAIN_INSTALL || ( !SUBDOMAIN_INSTALL && ( BLOG_ID_CURRENT_SITE != $blog_id ) ) ) )
 			) {
 				add_action( 'admin_bar_menu', array( $this, 'varnish_rightnow_adminbar' ), 100 );
 		}
@@ -175,7 +175,7 @@ class VarnishPurger {
 			// Multisite - Network Admin can always purge
 			current_user_can('manage_network') ||
 			// Multisite - Site admins can purge UNLESS it's a subfolder install and we're on site #1
-			( is_multisite() && !current_user_can('manage_network') && ( SUBDOMAIN_INSTALL || ( !SUBDOMAIN_INSTALL && ( BLOG_ID_CURRENT_SITE != $blog_id ) ) ) )
+			( is_multisite() && current_user_can( 'manage_options' ) && ( SUBDOMAIN_INSTALL || ( !SUBDOMAIN_INSTALL && ( BLOG_ID_CURRENT_SITE != $blog_id ) ) ) )
 		) {
 			$text = $intro.' '.$button;
 		} else {


### PR DESCRIPTION
Check if the user can manage_options before outputting the "Purge Varnish" button instead of checking if the user cannot manage_network

Fixes #27 