### PR TITLE
varnish-status: check isset( $headers['Server'] )

### DIFF
--- a/varnish-status.php
+++ b/varnish-status.php
@@ -239,7 +239,7 @@ class VarnishStatus {
 				?></tr><?php
 
 				// Cloudflare
-				if ( strpos( $headers['Server'] ,'cloudflare') !== false ) {
+				if ( isset( $headers['Server'] ) && strpos( $headers['Server'] ,'cloudflare') !== false ) {
 				?><tr>
 					<td><?php echo $icon_warning; ?></td>
 					<td><?php printf( __( 'Because CloudFlare is running, you may experience some cache oddities. Make sure you <a href="%s">configure WordPress for Cloudflare</a>?', 'varnish-http-purge'  ), '#configure' ); ?></td>


### PR DESCRIPTION
Love the new status page! Viewing it on local MAMP server I get :

( ! ) Notice: Undefined index: Server in .../wp-content/plugins/varnish-http-purge/varnish-status.php on line 242

Checking isset() fixes it as expected. Matched my fix to the other variables that you do check :)