### PR TITLE
Introduce `varnish_http_purge_headers` filter

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -310,9 +310,16 @@ class VarnishPurger {
 			$purgeme .= '?' . $p['query'];
 		}
 
+		/**
+		 * Filters the HTTP headers to send with a PURGE request.
+		 *
+		 * @since 4.0.3
+		 */
+		$headers = apply_filters( 'varnish_http_purge_headers', array( 'host' => $p['host'], 'X-Purge-Method' => $varnish_x_purgemethod ) );
+		
 		// Cleanup CURL functions to be wp_remote_request and thus better
 		// http://wordpress.org/support/topic/incompatability-with-editorial-calendar-plugin
-		$response = wp_remote_request($purgeme, array('method' => 'PURGE', 'headers' => array( 'host' => $p['host'], 'X-Purge-Method' => $varnish_x_purgemethod ) ) );
+		$response = wp_remote_request( $purgeme, array( 'method' => 'PURGE', 'headers' => $headers ) );
 
 		do_action('after_purge_url', $url, $purgeme, $response);
 	}

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -321,7 +321,7 @@ class VarnishPurger {
 		// http://wordpress.org/support/topic/incompatability-with-editorial-calendar-plugin
 		$response = wp_remote_request( $purgeme, array( 'method' => 'PURGE', 'headers' => $headers ) );
 
-		do_action('after_purge_url', $url, $purgeme, $response);
+		do_action( 'after_purge_url', $url, $purgeme, $response, $headers );
 	}
 
 	/**


### PR DESCRIPTION
The filter allows you to change the HTTP headers to send with a PURGE request.

My use case is adding the `X-Forwarded-Proto: https` header since my `vcl_hash` method includes the protocol in the hash.