### PR TITLE
Varnish HTTP Purge v 4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,6 @@ This is the development repository for the Varnish HTTP Purge plugin.
 
 You should install the plugin from the [WordPress.org Repository](http://wordpress.org/plugins/varnish-http-purge/) however the master branch will mirror that. Development happens on various `REL` branches.
 
-## Current Versions
-
-* Live - master (4.0.2)
-
 ## Helpful Links
 
 * [WP Readme](readme.txt)

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,31 @@
+= 4.0.3 =
+* Better explanation when Cloudflare gets in the way of DNS
+* Rename flush button for people who don't speak Varnish
+
+= 4.0.2 =
+* Support for WP-CLI commands and PHP > 5.5 (though please upgrade, props @robertpeake)
+* Better information regarding Cloudflare
+* Better failure on domains for scanner
+* Better IP detection
+* Break apart settings for faster saving
+
+= 4.0.1 =
+* Fix typo (on -> one)
+* Correct permissions on Multisite (props @phh - resolves #27 #28)
+* Correct weird merge error (props @phh - resolves #25 #26)
+* Fix formatting in Changelog
+
+= 4.0 =
+* Added Varnish Status Page - Tools -> Varnish Status (includes basic scanning etc)
+* Allow filter for `home_url()`
+* Update readme with list of filters.
+* Added wp-cli commands to flush specific URLs and wildcards
+* Requires wp-cli 0.25+ to work [3315](https://github.com/wp-cli/wp-cli/issues/3315) for WP 4.6+
+* Update `purgePost()` to validate page_for_posts ([Props JeremyClarke](https://github.com/Ipstenu/varnish-http-purge/pull/20))
+* Add check for AMP ([Props JeremyClarke](https://wordpress.org/support/topic/varnish-http-purge-doesnt-update-amp-urls-on-post-update/))
+* Purge 'default' AMP URL as well
+* Cleanup on Uninstall
+
 = 3.9.3 =
 * Update Documentation and Readme
 

--- a/readme.txt
+++ b/readme.txt
@@ -5,20 +5,21 @@ Requires at least: 4.0
 Tested up to: 4.8
 Stable tag: 4.1
 
-Automatically purge Varnish Cache when content on your site is modified.
+Automatically empty a Varnish Cache when content on your site is modified.
 
 == Description ==
-Varnish HTTP Purge sends a PURGE request to the URL of a page or post every time it it modified. This occurs when editing, publishing, commenting or deleting an item, and when changing themes.
 
-<a href="https://www.varnish-cache.org/">Varnish</a> is a web application accelerator also known as a caching HTTP reverse proxy. You install it in front of any server that speaks HTTP and configure it to cache the contents. This plugin <em>does not</em> install Varnish for you, nor does it configure Varnish for WordPress. It's expected you already did that on your own.
+Varnish HTTP Purge sends a PURGE request to delete the cached data of a page or post every time it it modified. This happens when updating, publishing, commenting on, or deleting an post, and when changing themes.
 
-Not all pages are purged every time, depending on your Varnish configuration. When a post, page, or custom post type is edited, or a new comment is added, <em>only</em> the following pages will purge:
+<a href="https://www.varnish-cache.org/">Varnish</a> is a web application accelerator also known as a caching HTTP reverse proxy. You install it in front of any server that speaks HTTP and configure it to cache the contents. This plugin <em>does not</em> install Varnish for you, nor will it configure Varnish for WordPress. It's expected you already did that on your own.
+
+Not all page caches are deleted every time, depending on your Varnish configuration. For example, when a post, page, or custom post type is edited, or a new comment is added, <em>only</em> the following pages will purge:
 
 * The front page
 * The post/page edited
 * Any categories or tags associated with the page
 
-In addition, your entire cache will be purged on the following actions:
+In addition, your <em>entire</em> cache will be deleted on the following actions:
 
 * Changing themes
 * Press the 'Purge Varnish Cache' button on the dashboard
@@ -28,14 +29,15 @@ Plugins can hook into the purge actions as well, to filter their own events to t
 
 And if you're into WP-CLI, you can use that too: `wp varnish purge`
 
-Please note: On a multisite network using subfolders, only <strong>network admins</strong> can purge the main site.
+Please note: On a multisite network using subfolders, only <strong>network admins</strong> can purge the main site. This is a security decision.
 
 == Installation ==
 No WordPress configuration needed.
 
-When used on Multisite, the plugin is Network Activatable Only.
+When used on Multisite, the plugin is only able to be activated Network Wide.
 
 = Requirements =
+
 * Pretty Permalinks enabled
 * Varnish 3.x or higher
 
@@ -47,51 +49,57 @@ If you have code patches, [pull requests are welcome](https://github.com/Ipstenu
 
 = How can I tell everything's working? =
 
-This can be difficult, since it's a silent plugin. That is you turn it on and walk away. The easiest way to tell would be view a page as a non-logged-in user. I recommend a private browsing window. Then, as a logged in user in another window, edit an existing post (make a small change). Refresh the view in your private window. If the change is there, then everything's working!
+From your WordPress Dashboard, go to Tools -> Varnish Status. There a page will auto-scan your main plugin page and report back any issues found. This includes any known problematic plugins.
 
 = Does every WordPress plugin and theme work with Varnish? =
 
-No. Some of them have behavior that causes Varnish not to cache. While debugging that is outside the scope of this plugin, there is an "Is Varnish Working?" tool (see WP Admin -> Tools -> Varnish Status) that tries to detect most of the common issues and direct you to resolutions.
+No. Some of them have behavior that causes Varnish not to cache. While I can't debug that for you, there is an "Is Varnish Working?" tool (see WP Admin -> Tools -> Varnish Status) that tries to detect most of the common issues and direct you to resolutions.
 
 = How can I debug my site? =
 
-From your WordPress Dashboard, go to Tools -> Varnish Status. There a page will auto-scan your main plugin page and report back any issues found. This includes any known problematic plugins.
+Use the Varnish Status page. It'll try and help you figure out what's wrong.
+
+= Will you fix my site if there's a conflict with a theme or plugin? =
+
+I wish I could. I don't have that much free time. What I can do is try and point you to how you can fix it yourself. Bear in mind, that may mean you have to decide if using a specific plugin or theme is worth an imperfect cache.
 
 = What version of Varnish is supported? =
 
 This was built and tested on Varnish 3.x. While it is reported to work on 2.x and 4.x, it is only supported on v3 at this time.
 
-= Why doesn't every page flush when I make a new post? =
+= Why doesn't every page cache get deleted when I make a new post? =
 
-The only pages that should purge are the post's page, the front page, categories, and tags. The reason why is a little philosophical.
+The only cache pages that should be deleted are the post's page, the front page, categories, and tags. The reason why is a little philosophical.
 
-When building out this plugin, there were a couple pathways on how best to handle purging caches and they boiled down to two: Decisions (the plugin purges what it purges when it purges) and Options (you decide what to purge, when and why). It's entirely possible to make this plugin purge everything, every time a 'trigger' happens, have it purge some things, or have it be so you can pick that purges.
+When building out this plugin, there were a couple pathways on how best to handle purging caches and they boiled down to two: Decisions (the plugin deletes what it deletes when it deems it appropriate) and Options (you decide what to delete, when and why). It's entirely possible to make this plugin delete everything in a cache, every time a 'trigger' happens, have it only delete prt of the cache, or have it be so you can pick what gets deleted.
 
-In the interests of design, we decided that the KISS principle was key. Since you can configure your Varnish to always purge all pages recursively (i.e. purging http://example.com/ would purge all pages below it), if that's a requirement, you can set it yourself. There are also other Varnish plugins that allow for more granular control (including W3 Total Cache), however this plugin will not be gaining a whole bunch of options to handle that.
+It was decided that the KISS principle was key. Since you can configure Varnish itself to always delete all pages recursively (i.e. purging `http://example.com/` would purge all pages below it), I felt it prudent to allow you to make that choice yourself in Varnish, not the plugin. There are also other plugins that allow for more granular control of Varnish and deleting caches (including W3 Total Cache).
 
-= Why doesn't my cache purge when I edit my theme? =
+In the interest of simplicity, this plugin will not be gaining a whole bunch of options to handle that.
 
-Because the plugin only purges your <em>content</em> when you edit it. That means if you edit a page/post, or someone leaves a comment, it'll change. Otherwise, you have to purge the whole cache. The plugin will do this for you if you activate a new theme, but not when you edit your current theme's files.
+= Why doesn't my cache get deleted when I edit my theme? =
 
-If you use Jetpack's CSS editor, it will purge the whole cache for your site on save.
+Because the plugin only deletes caches of your <em>content</em> when you edit it. That means if you edit a page/post, or someone leaves a comment, it'll delete the impacted cached content. Otherwise, you have to delete the whole cache. The plugin will do this for you if you activate a new theme, but not when you edit your current theme's files, and not when you use customizer to change your widgets etc.
 
-= How do I manually purge the whole cache? =
+However... If you use the CSS editor in customizer, it will empty the whole cache for your site on publish.
 
-Click the 'Purge Varnish Cache' button on the "Right Now" Dashboard (see the screenshot if you can't find it).
+= How do I manually delete the whole cache? =
 
-There's also a "Purge Varnish" button on the admin toolbar.
+Click the 'Empty Varnish Cache' button on the "Right Now" Dashboard (see the screenshot if you can't find it).
+
+There's also an "Empty Cache" button on the admin toolbar.
 
 = I don't see a button! =
 
-If you're on a Multisite Network and you're on the primary site in the network, only the <em>network</em> admins can purge that site
+If you're on a Multisite Network and you're on the primary site in the network, only the <em>network</em> admins can empty the cache for that site
 
-On a subfolder network if you flush the site at `example.com`, then everything under that (like `example.com/site1` and `example.com/siten` and everything else) would also get flushed. That means that a purge on the main site purges the entire network.
+On a subfolder network if you empty the cache for `example.com`, then everything under that (like `example.com/site1` and `example.com/site99` and everything in between) would also get flushed. That means that deleting the cache on the main site deletes the cache for the entire network. Which would really suck.
 
-In order to mitigate the destructive nature of that power, only the network admins can purge everything on the main site of a subfolder network.
+In order to mitigate the destructive nature of that power, only the network admins can empty the cache of the main site of a subfolder network.
 
 = Why is nothing caching when I use PageSpeed? =
 
-PageSpeed likes to put in Caching headers to say <em>not</em> to cache. To fix this, you need to put this in your .htaccess section for PageSpeed: `ModPagespeedModifyCachingHeaders off`
+PageSpeed likes to put in Caching headers to say <em>not</em> to cache. To fix this, you need to put this in your `.htaccess` section for PageSpeed: `ModPagespeedModifyCachingHeaders off`
 
 If you're using nginx, it's `pagespeed ModifyCachingHeaders off;`
 
@@ -101,7 +109,7 @@ Yes, but you'll need to make some additional changes (see "Why aren't my changes
 
 = Why aren't my changes showing when I use CloudFlare or another proxy? =
 
-When you use CloudFlare or any other similar service, you've got a proxy in front of the Varnish proxy. In general this isn't a bad thing. The problem arises when the DNS shenanigans send the purge request to your domain name. When you've got an additional proxy like CloudFlare, you don't want the request to go to the proxy, you want it to go to Varnish server.
+When you use CloudFlare or any other similar service, you've got a proxy in front of the Varnish proxy. In general this isn't a bad thing, though it can introduce some network latency (that means your site may run slower because it has to go through multiple layers to get to the content). The problem arises when the DNS shenanigans send the purge request to your domain name. When you've got an additional proxy like CloudFlare, you don't want the request to go to the proxy, you want it to go to Varnish server.
 
 On single-site, you can edit this via the Tools -> Varnish Status page. On Multisite, you'll need to add the following to your wp-config.php file:
 
@@ -124,7 +132,7 @@ Your Varnish IP must be one of the IPs that Varnish is listening on. If you use 
 If your webhost set up Varnish for you, you may need to ask them for the specifics if they don't have it documented. I've listed the ones I know about here, however you should still check with them if you're not sure.
 
 <ul>
-    <li><strong>DreamHost</strong> - If you're using DreamPress and Cloudflare, go into the Panel and click on the DNS settings for the domain. The entry for <em>resolve-to.domain</em> is your varnish server: `resolve-to.www A 208.97.157.172` -- If you're <em>NOT</em> using Cloudflare, you don't need it, but it's just your normal IP.</li>
+    <li><strong>DreamHost</strong> - If you're using DreamPress and Cloudflare, go into the Panel and click on the DNS settings for the domain. The entry for <em>resolve-to.domain</em> is your varnish server: `resolve-to.www A 208.97.157.172` -- If you're <em>NOT</em> using Cloudflare, you don't need it; it's just your normal IP.</li>
 </ul>
 
 = What if I have multiple varnish IPs? =
@@ -133,17 +141,17 @@ Multiple IPs are not supported at this time.
 
 I have a major issue with writing code I don't use, which means that since I'm only using one IP right now, I don't want to be on the ball for supporting multiple IPs. I don't even have a place to test it, which is just insane to attempt to code if you think about it. Yes, I could accept pull requests, but that means everyone's at some other person's discretion. So no, I won't be doing that at this time.
 
-= Why don't my gzip'd pages flush? =
+= Why don't my gzip'd pages get deleted? =
 
 Make sure your Varnish VCL is configured correctly to purge all the right pages. This is normally an issue with Varnish 2, which is not supported by this plugin.
 
-= Why isn't the whole cache purge working? =
+= Why isn't the whole cache deletion working? =
 
 The plugin sends a PURGE command of <code>/.*</code> and `X-Purge-Method` in the header with a value of regex. If your Varnish server doesn't doesn't understand the wildcard, you can configure it to check for the header.
 
-= How can I debug? =
+= How can I see what the plugin is sending to Varnish? =
 
-If `WP_DEBUG` is on and you're not seeing any errors, you'll have to jump into the command line.
+Danger! Here be dragons! If you're command line savvy, you can monitor the interactions between the plugin and Varnish. This can help you understand what's not working quite right, but it can very confusing.
 
 To see every request made to varnish, use this:
 `varnishncsa -F "%m %U"`
@@ -189,11 +197,13 @@ All of these VCLs work with this plugin.
 
 Yes! 
 
+
 * `vhp_home_url` - Change the home URL (default is `home_url()`)
 * `vhp_purge_urls` - Add additional URLs to what will be purged
+* `varnish_http_purge_headers` - Allows you to change the HTTP headers to send with a PURGE request. 
+* `varnish_http_purge_schema` - Allows you to change the schema (default is http)
 * `varnish_http_purge_events` - Add a specific event to trigger a page purge
 * `varnish_http_purge_events_full` - Add a specific event to trigger a full site purge
-* `varnish_http_purge_schema` - Allows you to change the schema (default is http)
 
 I strongly urge you to use the last one with caution. If you trigger a full site purge too often, you'll obviate the usefulness of caching!
 
@@ -205,13 +215,18 @@ If you don't have a post ID and you still need this, add it to *both* `varnish_h
 
 = Hey, don't you work at DreamHost? Is this Official or DreamHost only? =
 
-Yes I do, and yes and no. This plugin is installed by default for _all_ DreamPress installs on DreamHost, and I maintain it for DreamHost, but it was not originally an official DH plugin which means I will continue to support all users to the best of my ability.
+* Yes, I do work for DreamHost.
+* No, this plugin is not really official nor DreamHost Only
+
+This plugin is installed by default for _all_ DreamPress installs on DreamHost, and I maintain it for DreamHost, but it was not originally an official DH plugin which means I will continue to support all users to the best of my ability.
 
 == Changelog ==
 
 = 4.1 =
 
 * JSON / REST API Support
+* Fix for Varnish Status Page on MAMP (props @jeremyclarke)
+* Filter for purge headers (props @ocean90)
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -227,6 +227,7 @@ This plugin is installed by default for _all_ DreamPress installs on DreamHost, 
 * JSON / REST API Support
 * Fix for Varnish Status Page on MAMP (props @jeremyclarke)
 * Filter for purge headers (props @ocean90)
+* Disallow people from editing the Varnish IP on Multisite
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Varnish HTTP Purge ===
 Contributors: Ipstenu, mikeschroder, techpriester
 Tags: varnish, purge, cache
-Requires at least: 4.0
+Requires at least: 4.7
 Tested up to: 4.8
 Stable tag: 4.1
 
@@ -228,6 +228,7 @@ This plugin is installed by default for _all_ DreamPress installs on DreamHost, 
 * Fix for Varnish Status Page on MAMP (props @jeremyclarke)
 * Filter for purge headers (props @ocean90)
 * Disallow people from editing the Varnish IP on Multisite
+* Drop support for pre 4.7 because of JSON / REST API
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Ipstenu, mikeschroder, techpriester
 Tags: varnish, purge, cache
 Requires at least: 4.0
-Tested up to: 4.7
-Stable tag: 4.0.3
+Tested up to: 4.8
+Stable tag: 4.1
 
 Automatically purge Varnish Cache when content on your site is modified.
 
@@ -209,33 +209,9 @@ Yes I do, and yes and no. This plugin is installed by default for _all_ DreamPre
 
 == Changelog ==
 
-= 4.0.3 =
-* Better explanation when Cloudflare gets in the way of DNS
-* Rename flush button for people who don't speak Varnish
+= 4.1 =
 
-= 4.0.2 =
-* Support for WP-CLI commands and PHP > 5.5 (though please upgrade, props @robertpeake)
-* Better information regarding Cloudflare
-* Better failure on domains for scanner
-* Better IP detection
-* Break apart settings for faster saving
-
-= 4.0.1 =
-* Fix typo (on -> one)
-* Correct permissions on Multisite (props @phh - resolves #27 #28)
-* Correct weird merge error (props @phh - resolves #25 #26)
-* Fix formatting in Changelog
-
-= 4.0 =
-* Added Varnish Status Page - Tools -> Varnish Status (includes basic scanning etc)
-* Allow filter for `home_url()`
-* Update readme with list of filters.
-* Added wp-cli commands to flush specific URLs and wildcards
-* Requires wp-cli 0.25+ to work [3315](https://github.com/wp-cli/wp-cli/issues/3315) for WP 4.6+
-* Update `purgePost()` to validate page_for_posts ([Props JeremyClarke](https://github.com/Ipstenu/varnish-http-purge/pull/20))
-* Add check for AMP ([Props JeremyClarke](https://wordpress.org/support/topic/varnish-http-purge-doesnt-update-amp-urls-on-post-update/))
-* Purge 'default' AMP URL as well
-* Cleanup on Uninstall
+* JSON / REST API Support
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -229,6 +229,7 @@ This plugin is installed by default for _all_ DreamPress installs on DreamHost, 
 * Filter for purge headers (props @ocean90)
 * Disallow people from editing the Varnish IP on Multisite
 * Drop support for pre 4.7 because of JSON / REST API
+* Support flushing cache for private pages
 
 == Screenshots ==
 

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -41,7 +41,7 @@ class VarnishPurger {
 	 * @access public
 	 */
 	public function __construct( ) {
-		defined('VHP_VARNISH_IP') || define('VHP_VARNISH_IP', false );
+		defined( 'VHP_VARNISH_IP' ) || define( 'VHP_VARNISH_IP' , false );
 		add_action( 'init', array( &$this, 'init' ) );
 		add_action( 'admin_init', array( &$this, 'admin_init' ) );
 		add_action( 'activity_box_end', array( $this, 'varnish_rightnow' ), 100 );
@@ -63,8 +63,8 @@ class VarnishPurger {
 		}
 
 		// Warning: No Pretty Permalinks!
-		if ( '' == get_option( 'permalink_structure' ) && current_user_can('manage_options') ) {
-			add_action( 'admin_notices' , array( $this, 'require_pretty_permalinks_notice'));
+		if ( '' == get_option( 'permalink_structure' ) && current_user_can( 'manage_options' ) ) {
+			add_action( 'admin_notices' , array( $this, 'require_pretty_permalinks_notice' ) );
 			return;
 		}
 	}
@@ -93,28 +93,28 @@ class VarnishPurger {
 			foreach ( $events as $event) {
 				if ( in_array($event, $noIDevents ) ) {
 					// These events have no post ID and, thus, will perform a full purge
-					add_action( $event, array($this, 'purgeNoID') );
+					add_action( $event, array( $this, 'purgeNoID' ) );
 				} else {
-					add_action( $event, array($this, 'purgePost'), 10, 2 );
+					add_action( $event, array( $this, 'purgePost' ), 10, 2 );
 				}
 			}
 		}
 		
-		add_action( 'shutdown', array($this, 'executePurge') );
+		add_action( 'shutdown', array( $this, 'executePurge' ) );
 
 		// Success: Admin notice when purging
-		if ( isset($_GET['vhp_flush_all']) && check_admin_referer('vhp-flush-all') ) {
+		if ( isset( $_GET['vhp_flush_all'] ) && check_admin_referer( 'vhp-flush-all' ) ) {
 			add_action( 'admin_notices' , array( $this, 'purgeMessage'));
 		}
 
 		// Checking user permissions for who can and cannot use the admin button
 		if (
 			// SingleSite - admins can always purge
-			( !is_multisite() && current_user_can('activate_plugins') ) ||
+			( !is_multisite() && current_user_can( 'activate_plugins' ) ) ||
 			// Multisite - Network Admin can always purge
-			current_user_can('manage_network') ||
+			current_user_can( 'manage_network' ) ||
 			// Multisite - Site admins can purge UNLESS it's a subfolder install and we're on site #1
-			( is_multisite() && current_user_can('activate_plugins') && ( SUBDOMAIN_INSTALL || ( !SUBDOMAIN_INSTALL && ( BLOG_ID_CURRENT_SITE != $blog_id ) ) ) )
+			( is_multisite() && current_user_can( 'activate_plugins' ) && ( SUBDOMAIN_INSTALL || ( !SUBDOMAIN_INSTALL && ( BLOG_ID_CURRENT_SITE != $blog_id ) ) ) )
 			) {
 				add_action( 'admin_bar_menu', array( $this, 'varnish_rightnow_adminbar' ), 100 );
 		}
@@ -169,13 +169,13 @@ class VarnishPurger {
 	 *
 	 * @since 2.0
 	 */
-	function varnish_rightnow_adminbar($admin_bar){
+	function varnish_rightnow_adminbar( $admin_bar ){
 		$admin_bar->add_menu( array(
 			'id'	=> 'purge-varnish-cache-all',
-			'title' => __('Empty Cache','varnish-http-purge'),
+			'title' => __( 'Empty Cache', 'varnish-http-purge' ),
 			'href'  => wp_nonce_url( add_query_arg('vhp_flush_all', 1), 'vhp-flush-all'),
 			'meta'  => array(
-				'title' => __('Empty Cache','varnish-http-purge'),
+				'title' => __( 'Empty Cache', 'varnish-http-purge' ),
 			),
 		));
 	}
@@ -188,7 +188,7 @@ class VarnishPurger {
 	 */
 	function varnish_rightnow() {
 		global $blog_id;
-		$url = wp_nonce_url(add_query_arg('vhp_flush_all', 1), 'vhp-flush-all');
+		$url = wp_nonce_url( add_query_arg( 'vhp_flush_all', 1 ), 'vhp-flush-all' );
 		$intro = sprintf( __( '<a href="%1$s">Varnish HTTP Purge</a> automatically deletes your cached posts when published or updated. When making major site changes, such as with a new theme, plugins, or widgets, you may need to manually empty the cache.', 'varnish-http-purge' ), 'http://wordpress.org/plugins/varnish-http-purge/' );
 		$button =  __( 'Press the button below to force it to empty your entire Varnish cache.', 'varnish-http-purge' );
 		$button .= '</p><p><span class="button"><a href="'.$url.'"><strong>';
@@ -270,11 +270,11 @@ class VarnishPurger {
 
 		if ( empty( $purgeUrls ) ) {
 			if ( isset( $_GET['vhp_flush_all'] ) && check_admin_referer( 'vhp-flush-all' ) ) {
-				$this->purgeUrl( $this->the_home_url() .'/?vhp-regex' );
+				$this->purgeUrl( $this->the_home_url() . '/?vhp-regex' );
 			}
 		} else {
 			foreach( $purgeUrls as $url ) {
-				$this->purgeUrl($url);
+				$this->purgeUrl( $url );
 			}
 		}
 	}
@@ -287,8 +287,8 @@ class VarnishPurger {
 	 * @param array $url the url to be purged
 	 * @access protected
 	 */
-	public function purgeUrl($url) {
-		$p = parse_url($url);
+	public function purgeUrl( $url ) {
+		$p = parse_url( $url );
 
 		// Determine if we're using regex to flush all pages or not
 		$pregex = '';
@@ -309,7 +309,7 @@ class VarnishPurger {
 
 		// Determine the path
 		$path = '';
-		if ( isset($p['path'] ) ) {
+		if ( isset( $p['path'] ) ) {
 			$path = $p['path'];
 		}
 
@@ -332,7 +332,7 @@ class VarnishPurger {
 
 		$purgeme = $schema.$host.$path.$pregex;
 
-		if ( !empty($p['query']) && $p['query'] != 'vhp-regex' ) {
+		if ( !empty( $p['query'] ) && $p['query'] != 'vhp-regex' ) {
 			$purgeme .= '?' . $p['query'];
 		}
 
@@ -360,7 +360,7 @@ class VarnishPurger {
 	public function purgeNoID( $postId ) {
 		$listofurls = array();
 
-		array_push( $listofurls, $this->the_home_url().'/?vhp-regex' );
+		array_push( $listofurls, $this->the_home_url() . '/?vhp-regex' );
 	
 		// Now flush all the URLs we've collected provided the array isn't empty
 		if ( !empty( $listofurls ) ) {
@@ -380,7 +380,9 @@ class VarnishPurger {
 	 */
 	public function purgePost( $postId ) {
 		
-		global $wp_version;
+		// Future Me: You may need this if you figure out how to use an array
+		// further down with versions of WP and their json versions.
+		// global $wp_version;
 		
 		// If this is a valid post we want to purge the post, 
 		// the home page and any associated tags and categories
@@ -411,11 +413,11 @@ class VarnishPurger {
 			// But we apparently have to force it for posts and pages (seriously?)
 			$post_type_object = get_post_type_object( $postId );	
 			if ( isset( $post_type_object->rest_base ) ) {
-				$rest_permalink = get_rest_url().$rest_api_route.'/'.$post_type_object->rest_base.'/'.$postId.'/';
+				$rest_permalink = get_rest_url() . $rest_api_route . '/' . $post_type_object->rest_base . '/' . $postId . '/';
 			} elseif ( $this_post_type == 'post' ) {
-				$rest_permalink = get_rest_url().$rest_api_route.'/posts/'.$postId.'/';
+				$rest_permalink = get_rest_url() . $rest_api_route . '/posts/' . $postId . '/';
 			} elseif ( $this_post_type == 'page' ) {
-				$rest_permalink = get_rest_url().$rest_api_route.'/pages/'.$postId.'/';
+				$rest_permalink = get_rest_url() . $rest_api_route . '/pages/' . $postId . '/';
 			}
 			array_push( $listofurls, $rest_permalink );
 
@@ -425,13 +427,13 @@ class VarnishPurger {
 			}
 			
 			// Regular AMP url for posts
-			array_push( $listofurls, get_permalink( $postId ).'amp/' );
+			array_push( $listofurls, get_permalink( $postId ) . 'amp/' );
 
 			// Also clean URL for trashed post.
 			if ( $this_post_status == 'trash' ) {
 				$trashpost = get_permalink( $postId );
 				$trashpost = str_replace( '__trashed', '', $trashpost );
-				array_push( $listofurls, $trashpost, $trashpost.'feed/' );
+				array_push( $listofurls, $trashpost, $trashpost . 'feed/' );
 			}
 
 			// Category purge based on Donnacha's work in WP Super Cache
@@ -440,7 +442,7 @@ class VarnishPurger {
 				foreach ( $categories as $cat ) {
 					array_push( $listofurls, 
 						get_category_link( $cat->term_id ),
-						get_rest_url().$rest_api_route.'/categories/'.$cat->term_id.'/'
+						get_rest_url() . $rest_api_route . '/categories/' . $cat->term_id . '/'
 					);
 				}
 			}
@@ -450,7 +452,7 @@ class VarnishPurger {
 				foreach ( $tags as $tag ) {
 					array_push( $listofurls, 
 						get_tag_link( $tag->term_id ),
-						get_rest_url().$rest_api_route.'/tags/'.$tag->term_id.'/'
+						get_rest_url() . $rest_api_route . '/tags/' . $tag->term_id . '/'
 					);
 				}
 			}
@@ -460,7 +462,7 @@ class VarnishPurger {
 			array_push( $listofurls,
 				get_author_posts_url( $author_id ),
 				get_author_feed_link( $author_id ),
-				get_rest_url().$rest_api_route.'/users/'.$author_id.'/'
+				get_rest_url() . $rest_api_route . '/users/' . $author_id . '/'
 			);
 
 			// Archives and their feeds
@@ -485,12 +487,12 @@ class VarnishPurger {
 			// Home Pages and (if used) posts page
 			array_push( $listofurls, 
 				get_rest_url(),
-				$this->the_home_url().'/'
+				$this->the_home_url() . '/'
 				);
-			if ( get_option('show_on_front') == 'page' ) {
+			if ( get_option( 'show_on_front' ) == 'page' ) {
 				// Ensure we have a page_for_posts setting to avoid empty URL
 				if ( get_option('page_for_posts') ) {
-					array_push( $listofurls, get_permalink( get_option('page_for_posts') ) );
+					array_push( $listofurls, get_permalink( get_option( 'page_for_posts' ) ) );
 				}
 			}
 			

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -345,12 +345,14 @@ class VarnishPurger {
 	 */
 	public function purgePost( $postId ) {
 		
+		global $wp_version;
+		
 		// If this is a valid post we want to purge the post, 
 		// the home page and any associated tags and categories
 
 		$validPostStatus = array("publish", "trash");
-		$thisPostStatus  = get_post_status($postId);
-		$rest_api_route  = 'wp/v2';
+		$thisPostStatus  = get_post_status($postId);	
+		$rest_api_route  = 'wp/v2'; // This may need to be revisted if WP updates the version. Gleep.
 
 		// array to collect all our URLs
 		$listofurls = array();
@@ -382,9 +384,11 @@ class VarnishPurger {
 			}
 
 			// Author URL
+			$author_id = get_post_field( 'post_author', $postId );
 			array_push($listofurls,
-				get_author_posts_url( get_post_field( 'post_author', $postId ) ),
-				get_author_feed_link( get_post_field( 'post_author', $postId ) )
+				get_author_posts_url( $author_id ),
+				get_author_feed_link( $author_id ),
+				get_rest_url().$rest_api_route.'/users/'.$author_id.'/'
 			);
 
 			// Archives and their feeds

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -3,14 +3,14 @@
 Plugin Name: Varnish HTTP Purge
 Plugin URI: https://halfelf.org/plugins/varnish-http-purge/
 Description: Automatically purge Varnish Cache when content on your site is modified.
-Version: 4.0.3
+Version: 4.1-beta
 Author: Mika Epstein
 Author URI: https://halfelf.org/
 License: http://www.apache.org/licenses/LICENSE-2.0
 Text Domain: varnish-http-purge
 Network: true
 
-	Copyright 2013-2016: Mika A. Epstein (email: ipstenu@halfelf.org)
+	Copyright 2013-2017: Mika A. Epstein (email: ipstenu@halfelf.org)
 
 	Original Author: Leon Weidauer ( http:/www.lnwdr.de/ )
 
@@ -357,6 +357,7 @@ class VarnishPurger {
 		$listofurls = array();
 
 		if( get_permalink($postId) == true && in_array($thisPostStatus, $validPostStatus) ) {
+
 			// If this is a post with a permalink AND it's published or trashed, 
 			// we're going to add a ton of things to flush.
 			
@@ -364,14 +365,20 @@ class VarnishPurger {
 			$categories = get_the_category($postId);
 			if ( $categories ) {
 				foreach ($categories as $cat) {
-					array_push($listofurls, get_category_link( $cat->term_id ) );
+					array_push($listofurls, 
+						get_category_link( $cat->term_id ),
+						get_rest_url().'wp/v2/categories/'.$cat->term_id.'/'
+					);
 				}
 			}
 			// Tag purge based on Donnacha's work in WP Super Cache
 			$tags = get_the_tags($postId);
 			if ( $tags ) {
 				foreach ($tags as $tag) {
-					array_push($listofurls, get_tag_link( $tag->term_id ) );
+					array_push($listofurls, 
+						get_tag_link( $tag->term_id ),
+						get_rest_url().'wp/v2/tags/'.$tag->term_id.'/'
+					);
 				}
 			}
 
@@ -417,6 +424,16 @@ class VarnishPurger {
 				get_bloginfo_rss('comments_rss2_url'),
 				get_post_comments_feed_link($postId)
 			);
+
+			// JSON API
+			array_push($listofurls,
+				get_rest_url(), // base URL
+			
+				'http://demo.wp-api.org/wp-json/wp/v2/posts/'.$postId
+				
+				/wp/v2/categories/
+				
+				http://demo.wp-api.org/wp-json/wp/v2/pages/
 
 			// Home Page and (if used) posts page
 			array_push( $listofurls, $this->the_home_url().'/' );

--- a/varnish-status.php
+++ b/varnish-status.php
@@ -115,7 +115,7 @@ class VarnishStatus {
 		<input type="text" id="vhp_varnish_ip" name="vhp_varnish_ip" value="<?php echo $varniship; ?>" size="25" <?php if ( $disabled == true ) { echo 'disabled'; } ?>/>
 		<label for="vhp_varnish_ip">
 			<?php
-			} elseif ( $disabled == true ) { 
+			if ( $disabled == true ) { 
 				_e('The Varnish IP has been defined in your wp-config, so it is not editable here.', 'varnish-http-purge');
 			} else {
 				_e('Example:', 'varnish-http-purge'); ?> <code>123.45.67.89</code><?php

--- a/varnish-status.php
+++ b/varnish-status.php
@@ -231,7 +231,7 @@ class VarnishStatus {
 					} elseif ( $remote_ip !== false && $remote_ip !== $varniship ) {
 					?>
 						<td width="40px"><?php echo $icon_warning; ?></td>
-						<td><?php printf( __( 'You\'re using a Custom Varnish IP that doesn\'t appear to match your server IP address. If you\'re using multiple Varnish servers, this is fine. Please make sure you\'ve <a href="%s">properly configured it</a> according to your webhost\'s specifications.', 'varnish-http-purge'  ), '#configure' ); ?></td>
+						<td><?php printf( __( 'You\'re using a Custom Varnish IP that doesn\'t appear to match your server IP address. If you\'re using multiple Varnish servers or IPv6, this is fine. Please make sure you\'ve <a href="%s">properly configured it</a> according to your webhost\'s specifications.', 'varnish-http-purge'  ), '#configure' ); ?></td>
 					<?php
 					} else {
 					?>

--- a/varnish-status.php
+++ b/varnish-status.php
@@ -43,9 +43,8 @@ class VarnishStatus {
 	 * @since 4.0
 	 */
 	function admin_init() {
-		// Register Settings
-		$this->register_settings_url();
-		$this->register_settings_ip();
+		$this->register_settings_url();		
+		if ( !is_multisite() ) $this->register_settings_ip();
 	}
 
 	/**
@@ -64,7 +63,6 @@ class VarnishStatus {
 	 */
 	function register_settings_url() {
 		register_setting( 'varnish-http-purge-url', 'vhp_varnish_url', array( &$this, 'varnish_url_sanitize' ) );
-
 		add_settings_section( 'varnish-url-settings-section', __('Check Varnish Status', 'varnish-http-purge'), array( &$this, 'options_callback_url'), 'varnish-url-settings' );
 		add_settings_field( 'varnish_url', __('Check A URL On Your Site:', 'varnish-http-purge'), array( &$this, 'varnish_url_callback'), 'varnish-url-settings', 'varnish-url-settings-section' );
 	}
@@ -76,7 +74,6 @@ class VarnishStatus {
 	 */
 	function register_settings_ip() {
 		register_setting( 'varnish-http-purge-ip', 'vhp_varnish_ip', array( &$this, 'varnish_ip_sanitize' ) );
-		
 		add_settings_section( 'varnish-ip-settings-section', __('Configure Custom Varnish IP', 'varnish-http-purge'), array( &$this, 'options_callback_ip'), 'varnish-ip-settings' );		
 		add_settings_field( 'varnish_ip', __('Set Varnish IP', 'varnish-http-purge'), array( &$this, 'varnish_ip_callback'), 'varnish-ip-settings', 'varnish-ip-settings-section' );
 	}
@@ -96,7 +93,6 @@ class VarnishStatus {
 		<ul>
 		    <li><?php _e('DreamHost - Go into the Panel and click on the DNS settings for the domain. The entry for <em>resolve-to.domain</em> (if set) will your varnish server. If it\'s not set, then you don\'t need to worry about this at all. Example:', 'varnish-http-purge'); ?> <code>resolve-to.www A 208.97.157.172</code></li>
 		</ul>
-
 	    <?php
 	}
 
@@ -115,18 +111,19 @@ class VarnishStatus {
 		} else {
 			$varniship = get_option('vhp_varnish_ip');
 		}
+				
 		?>
 		<input type="text" id="vhp_varnish_ip" name="vhp_varnish_ip" value="<?php echo $varniship; ?>" size="25" <?php if ( $disabled == true ) { echo 'disabled'; } ?>/>
 		<label for="vhp_varnish_ip">
 			<?php
-			if ( $disabled == true ) { 
+			} elseif ( $disabled == true ) { 
 				_e('The Varnish IP has been defined in your wp-config, so it is not editable here.', 'varnish-http-purge');
 			} else {
 				_e('Example:', 'varnish-http-purge'); ?> <code>123.45.67.89</code><?php
 			}
 			?>
 		</label>
-	<?php
+		<?php
 	}
 
 	/**

--- a/varnish-status.php
+++ b/varnish-status.php
@@ -9,10 +9,9 @@
 	Varnish HTTP Purge is distributed in the hope that it will be useful,
 	but WITHOUT ANY WARRANTY; without even the implied warranty of
 	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
-	
 */
 
-if (!defined('ABSPATH')) {
+if ( !defined('ABSPATH') ) {
     die();
 }
 


### PR DESCRIPTION
**Major Release**

The biggest part of this is that we're supporting the REST API more fully. However we're also dropping pre-4.7 support in doing so (the older versions will work on older WP). Two pull requests for filters by trusted WP community peoples are included, as well as support for Private pages (not an issue on DreamPress but possibly for others) and a lot of code formatting cleanup.

* JSON / REST API Support
* Fix for Varnish Status Page on MAMP (props @jeremyclarke)
* Filter for purge headers (props @ocean90)
* Disallow people from editing the Varnish IP on Multisite
* Drop support for pre 4.7 because of JSON / REST API
* Support flushing cache for private pages
