### PR TITLE
Introduce `--include-grep` flag for grepping common cache issues

### DIFF
--- a/wp-cli.php
+++ b/wp-cli.php
@@ -144,6 +144,9 @@ if ( !class_exists( 'WP_CLI_Varnish_Command' ) ) {
 		 * [--include-headers]
 		 * : Include headers in debug check output.
 		 *
+		 * [--include-grep]
+		 * : Also grep active theme and plugin directories for common issues.
+		 *
 		 * [--format=<format>]
 		 * : Render output in a particular format.
 		 * ---
@@ -170,6 +173,34 @@ if ( !class_exists( 'WP_CLI_Varnish_Command' ) ) {
 
 			if ( empty( $url ) ) {
 				$url = esc_url( $this->varnish_purge->the_home_url() );;
+			}
+
+			if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'include-grep' ) ) {
+				$pattern = '(PHPSESSID|session_start|start_session|$cookie|setCookie)';
+				WP_CLI::log( 'Grepping for: ' . $pattern );
+				WP_CLI::log( '' );
+				$paths = array(
+					get_template_directory(),
+					get_stylesheet_directory(),
+				);
+				foreach ( wp_get_active_and_valid_plugins() as $plugin_path ) {
+					// We don't care about our own plugin.
+					if ( false !== stripos( $plugin_path, 'varnish-http-purge/varnish-http-purge.php' ) ) {
+						continue;
+					}
+					$paths[] = dirname( $plugin_path );
+				}
+				$paths = array_unique( $paths );
+				foreach ( $paths as $path ) {
+					$cmd = sprintf(
+						"grep -RE '%s' %s",
+						$pattern,
+						escapeshellarg( $path )
+					);
+					passthru( $cmd );
+				}
+				WP_CLI::log( '' );
+				WP_CLI::log( 'Grep complete.' );
 			}
 
 			// Include the debug code


### PR DESCRIPTION
Works like this:

<img width="1213" alt="image" src="https://user-images.githubusercontent.com/36432/41733861-1b144858-753a-11e8-9a55-6fe2f0a0b542.png">

Notably, it only greps the active theme and active plugins, which should increase performance over grepping the entirety of `wp-content`.

Fixes #47 