### PR TITLE
Admin bar 'Purge Cache (This Page)' URL uses filtered the_home_url

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -343,7 +343,7 @@ class VarnishPurger {
 
 			// If we're on a front end page and the current user can edit published posts, then they can do this.
 			if ( ! is_admin() && get_post() !== false && current_user_can( 'edit_published_posts' ) ) {
-				$page_url = esc_url( home_url( $wp->request ) );
+				$page_url = esc_url( str_replace( home_url(), $this->the_home_url(), home_url( $wp->request ) ) );
 				$args[]   = array(
 					'parent' => 'purge-varnish-cache',
 					'id'     => 'purge-varnish-cache-this',

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -343,7 +343,7 @@ class VarnishPurger {
 
 			// If we're on a front end page and the current user can edit published posts, then they can do this.
 			if ( ! is_admin() && get_post() !== false && current_user_can( 'edit_published_posts' ) ) {
-				$page_url = esc_url( str_replace( home_url(), $this->the_home_url(), home_url( $wp->request ) ) );
+				$page_url = esc_url( $this->the_home_url() . $wp->request );
 				$args[]   = array(
 					'parent' => 'purge-varnish-cache',
 					'id'     => 'purge-varnish-cache-this',


### PR DESCRIPTION
Maybe there's another way around this but I don't see it. 

I have a Wordpress instance running on two different domains: *admin.my.domain* and *my.domain*. Varnish sits in front of my.domain.

I use the the `vhp_home_url` to filter `the_home_url()` to my.domain.

However, because `varnish_rightnow_adminbar()` builds the *Purge Cache (This Page)* URL using `home_url( $wp->request )` that URL ends up being *admin.my.domain/$wp->request*. This PR does a string replacement using `$this->the_home_url()`. If no `vhp_home_url()` is set, the result should be the same as calling `home_url( $wp->request )`. But if one is set, then the URL to clear the current page will be corrected to the filtered vhp_home_url.

Thanks for considering.

