### PR TITLE
fix php notice: undefined variable proxy_ip

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -611,7 +611,7 @@ class VarnishPurger {
 
 		$parsed_url = $url;
 		// Filter URL based on the Proxy IP for nginx compatibility
-		if ( 'localhost' === $proxy_ip ) {
+		if ( ! empty( $proxy_ip ) && 'localhost' === $proxy_ip ) {
 			$parsed_url = str_replace( $p['host'], 'localhost', $parsed_url );
 		}
 


### PR DESCRIPTION
I'm running the plugin on VVV (nginx).

I had a PHP notice appearing in my logs this afternoon, I think it happened when the cron executed.

```
[05-Oct-2018 14:35:09 UTC] PHP Notice:  Undefined variable: proxy_ip in /srv/www/www.my-gcsescience.com/public_html/content/plugins/varnish-http-purge/varnish-http-purge.php on line 614
```