### PR TITLE
Jetpack: check if class exists before to use it

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -102,7 +102,7 @@ class VarnishPurger {
 	public function admin_init() {
 
 		// If WordPress.com Master Bar is active, show the activity box.
-		if ( is_plugin_active( 'jetpack/jetpack.php' ) && Jetpack::is_module_active( 'masterbar' ) ) {
+		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'masterbar' ) ) {
 			add_action( 'activity_box_end', array( $this, 'varnish_rightnow' ), 100 );
 		}
 


### PR DESCRIPTION
This should solve issues like the one reported here:
https://wordpress.org/support/topic/fatal-error-uncaught-erorr-class-jetpack-not-found/

I suspect this may have happened because Jetpack was installed as an mu-plugin, or inside a different folder. This should fix things.