### PR TITLE
Allow clear cache for Url with query and Regex

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -559,7 +559,7 @@ class VarnishPurger {
 		$pregex         = '';
 		$x_purge_method = 'default';
 
-		if ( isset( $p['query'] ) && ( 'vhp-regex' === $p['query'] ) ) {
+		if (strpos($url, '.*') !== false or ( isset( $p['query'] ) && ( 'vhp-regex' === $p['query'] ) ) ) {
 			$pregex         = '.*';
 			$x_purge_method = 'regex';
 		}


### PR DESCRIPTION
Example clear URL: http://domain.com/?parameter1=.*&parameter2=.*