### PR TITLE
Rel 4.8

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,26 @@
 ## CHANGELOG
 
+= 4.7.3 =
+* December 2018
+* Bugfix for Jetpack (Props @jherve)
+
+= 4.7.2 =
+* October 2018
+* Fix regression with IP function name
+* Restore "Right Now" activity box _only_ for people who use WP.com toolbar
+
+= 4.7.1 =
+* October 2018
+* Documentation: Cleaning up language and spelling
+
+= 4.7.0 =
+* October 2018
+* WP-CLI: documentation
+* Bugfix: Nginx compatibility
+* Bugfix: Only enqueue CSS on front0end if the admin bar is used (props @mathieuhays)
+* Feature: Rebranding
+* Deprecation: "Right Now" button (not needed anymore)
+
 = 4.6.6 =
 * September 2018
 * Bugfix to allow Nginx proxy to flush individual pages.

--- a/debug.php
+++ b/debug.php
@@ -267,7 +267,7 @@ class VarnishDebug {
 
 			// Which service are we?
 			$cache_service = false;
-			if ( $x_varnish && $x_nginx ) {
+			if ( $x_nginx ) {
 				$cache_service  = __( 'Nginx', 'varnish-http-purge' );
 				$still_cachable = ( $is_cachable && $x_age_nginx && $x_varn_hit && $x_pragma ) ? true : false;
 			} elseif ( $x_varnish && ! $x_nginx ) {

--- a/debug.php
+++ b/debug.php
@@ -26,41 +26,16 @@ class VarnishDebug {
 		$return  = false;
 		$newmode = get_site_option( 'vhp_varnish_devmode', VarnishPurger::$devmode );
 
-		// Make sure pause is properly flagged.
-		$is_paused = self::importer_check();
-		if ( $is_paused || ( isset( $newmode['pause'] ) && $newmode['pause'] ) ) {
-			self::devmode_toggle( 'pause' );
-		}
-
 		if ( VHP_DEVMODE ) {
 			// If the define is set, we're true.
 			$return = true;
-		} elseif ( isset( $newmode['active'] ) && $newmode['active'] ) {
-			if ( ! $newmode['pause'] && $newmode['expire'] <= current_time( 'timestamp' ) ) {
+		} elseif ( $newmode['active'] ) {
+			$return = true;
+			if ( $newmode['expire'] <= current_time( 'timestamp' ) ) {
 				// if expire is less that NOW, it's over.
 				self::devmode_toggle( 'deactivate' );
 				$return = false;
-			} else {
-				$return = true;
 			}
-		}
-
-		return $return;
-	}
-
-	/**
-	 * Check if Importer is running
-	 *
-	 * @access public
-	 * @static
-	 * @return string  true|false
-	 * @since 4.8
-	 */
-	public static function importer_check() {
-		$return = false;
-
-		if ( defined( 'WP_LOAD_IMPORTERS' ) ) {
-			$return = true;
 		}
 
 		return $return;
@@ -77,15 +52,13 @@ class VarnishDebug {
 	public static function devmode_toggle( $state = 'deactivate' ) {
 		$newmode = get_site_option( 'vhp_varnish_devmode', VarnishPurger::$devmode );
 
-		$newmode['expire'] = current_time( 'timestamp' ) + DAY_IN_SECONDS;
+		$expire_time       = ( 'pause' === $state ) ? MINUTE_IN_SECONDS : DATE_IN_SECONDS;
+		$newmode['expire'] = current_time( 'timestamp' ) + $expire_time;
 
 		switch ( sanitize_text_field( $state ) ) {
 			case 'activate':
-				$newmode['active'] = true;
-				break;
 			case 'pause':
 				$newmode['active'] = true;
-				$newmode['pause']  = true;
 				break;
 			case 'toggle':
 				$newmode['active'] = ( self::devmode_check() ) ? false : true;

--- a/debug.php
+++ b/debug.php
@@ -50,14 +50,11 @@ class VarnishDebug {
 	 * @return true|false
 	 */
 	public static function devmode_toggle( $state = 'deactivate' ) {
-		$newmode = get_site_option( 'vhp_varnish_devmode', VarnishPurger::$devmode );
-
-		$expire_time       = ( 'pause' === $state ) ? MINUTE_IN_SECONDS : DATE_IN_SECONDS;
-		$newmode['expire'] = current_time( 'timestamp' ) + $expire_time;
+		$newmode           = get_site_option( 'vhp_varnish_devmode', VarnishPurger::$devmode );
+		$newmode['expire'] = current_time( 'timestamp' ) + DAY_IN_SECONDS;
 
 		switch ( sanitize_text_field( $state ) ) {
 			case 'activate':
-			case 'pause':
 				$newmode['active'] = true;
 				break;
 			case 'toggle':

--- a/debug.php
+++ b/debug.php
@@ -182,10 +182,20 @@ class VarnishDebug {
 		// Lazy run twice to make sure we get a primed cache page.
 		$response1 = wp_remote_get( $url, $args );
 
+		// If this fails, we're going to assume bad things...
+		if ( is_wp_error( $response1 ) ) {
+			return 'fail';
+		}
+
 		// Because the 'Age' header is an important check, wait a second before fetching again.
 		sleep( 1 );
 
 		$response2 = wp_remote_get( $url, $args );
+
+		// And if this fails, we again assume badly.
+		if ( is_wp_error( $response2 ) ) {
+			return 'fail';
+		}
 
 		return $response2;
 	}

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ That will break cache on page loads. It is _not_ recommended for production!
 
 * `wp varnish purge` - Flush the entire cache
 * `wp varnish debug [<url>]` - Help for debugging how well your cache is (or isn't) working
-* `wp varnish devmode [<activate|deactivate|pause|toggle>]` - Change development mode state
+* `wp varnish devmode [<activate|deactivate|toggle>]` - Change development mode state
 
 = Privacy Policy =
 

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,7 @@ One common method of caching content for websites is via the use of reverse prox
 
 A reverse proxy cache is installed in front of a server and reviews requests. If the page being requested is already cached, it delivers the cached content. Otherwise it generates the page and the cache on demand.
 
-The Proxy Cache Purge plugin sends a request to delete (aka flush) the cached data of a page or post every time it it modified. This happens when updating, publishing, commenting on, or deleting an post, and when changing themes.
+The Proxy Cache Purge plugin sends a request to delete (aka flush) the cached data of a page or post every time it's modified.
 
 = How It Works =
 
@@ -52,7 +52,7 @@ That will break cache on page loads. It is _not_ recommended for production!
 
 * `wp varnish purge` - Flush the entire cache
 * `wp varnish debug [<url>]` - Help for debugging how well your cache is (or isn't) working
-* `wp varnish devmode [<activate|deactivate|toggle>` - Change development mode state
+* `wp varnish devmode [<activate|deactivate|toggle>]` - Change development mode state
 
 = Privacy Policy =
 

--- a/readme.txt
+++ b/readme.txt
@@ -115,11 +115,15 @@ There are three ways to do this:
 
 1. Chose 'Pause Cache (24hrs)' from the Cache dropdown menu in your toolbar
 2. Go to Proxy Cache -> Settings and enable development mode
-3. Add `define( 'VHP_DEVMODE', true );` to your `wp-config.php` file
+3. Add `define( 'VHP_DEVMODE', true );` to your `wp-config.php` file.
 
 The first two options will enable development mode for 24 hours. If you're working on long term development, you can should use the define.
 
 It is _not_ recommended you use development mode on production sites for extended periods of time, as it _will_ will slow your site down and lose all the benefits of caching in the first place.
+
+= Why is the restart cache button missing? =
+
+If you've disabled caching via the define, then you cannot restart cache via the plugin. You would need to change  `define( 'VHP_DEVMODE', true );` to  `define( 'VHP_DEVMODE', false );` in your `wp-config.php` file.
 
 = Why don't I have access to development mode? =
 
@@ -128,6 +132,10 @@ Due to the damage this can cause a site, access is limited to admins only. In th
 = Why do I still see cached content in development mode? =
 
 While development mode is on, your server will continue to cache content but the plugin will tell WordPress not to use the cached content. That means files that exist outside of WordPress (like CSS or images) _may_ serve cached content. The plugin does its best to add a No Cache parameter to javascript and CSS, however if a theme or plugin _doesn't_ use proper WordPress enqueues, then their cached content will be shown.
+
+= Why can I still flush cache while in development mode? =
+
+Because the server is still caching content. The plugin provides a way to flush the cache for those pages, as well as anything not included in WordPress, for your convinence.
 
 = How can I tell if everything's caching? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -135,7 +135,7 @@ While development mode is on, your server will continue to cache content but the
 
 = Why can I still flush cache while in development mode? =
 
-Because the server is still caching content. The plugin provides a way to flush the cache for those pages, as well as anything not included in WordPress, for your convinence.
+Because the server is still caching content. The plugin provides a way to flush the cache for those pages, as well as anything not included in WordPress, for your convenience.
 
 = How can I tell if everything's caching? =
 

--- a/readme.txt
+++ b/readme.txt
@@ -199,6 +199,7 @@ This plugin is installed by default for _all_ DreamPress installs on DreamHost, 
 * March 2019
 * Improve debugger
 * Clean code per standards
+* Improve callback on WP-CLI
 
 == Screenshots ==
 

--- a/readme.txt
+++ b/readme.txt
@@ -52,7 +52,7 @@ That will break cache on page loads. It is _not_ recommended for production!
 
 * `wp varnish purge` - Flush the entire cache
 * `wp varnish debug [<url>]` - Help for debugging how well your cache is (or isn't) working
-* `wp varnish devmode [<activate|deactivate|toggle>]` - Change development mode state
+* `wp varnish devmode [<activate|deactivate|pause|toggle>]` - Change development mode state
 
 = Privacy Policy =
 

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: Ipstenu, mikeschroder, techpriester, danielbachhuber
 Tags: proxy, purge, cache, varnish, nginx
 Requires at least: 4.7
-Tested up to: 5.0
-Stable tag: 4.7.3
+Tested up to: 5.1
+Stable tag: 4.8
 Requires PHP: 5.6
 
 Automatically empty proxy cached content when your site is modified.
@@ -195,26 +195,10 @@ This plugin is installed by default for _all_ DreamPress installs on DreamHost, 
 
 == Changelog ==
 
-= 4.7.3 =
-* December 2018
-* Bugfix for Jetpack (Props @jherve)
-
-= 4.7.2 =
-* October 2018
-* Fix regression with IP function name
-* Restore "Right Now" activity box _only_ for people who use WP.com toolbar
-
-= 4.7.1 =
-* October 2018
-* Documentation: Cleaning up language and spelling
-
-= 4.7.0 =
-* October 2018
-* WP-CLI: documentation
-* Bugfix: Nginx compatibility
-* Bugfix: Only enqueue CSS on front0end if the admin bar is used (props @mathieuhays)
-* Feature: Rebranding
-* Deprecation: "Right Now" button (not needed anymore)
+= 4.8 =
+* March 2019
+* Improve debugger
+* Clean code per standards
 
 == Screenshots ==
 

--- a/settings.php
+++ b/settings.php
@@ -322,6 +322,7 @@ class VarnishStatus {
 					foreach ( $headers as $header => $key ) {
 						if ( '0' !== $header ) {
 							if ( is_array( $key ) ) {
+								// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 								$content = print_r( $key, true );
 							} else {
 								$content = wp_kses_post( $key );

--- a/todo.txt
+++ b/todo.txt
@@ -2,7 +2,5 @@
 
 We're going to sit down and look into how the plugin is structured to make it even faster and more organized. Please send coffee. Here's the wish list:
 
-* Only purge all automatically once an hour (manual button click will continue to work)
 * Refactor automated purge all to be kinder
-* Reorganize code for sanity
 * Get rid of the need to parse_url()

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -412,30 +412,33 @@ class VarnishPurger {
 				);
 			}
 
-			// Populate enable/disable cache button.
-			if ( VarnishDebug::devmode_check() ) {
-				$purge_devmode_title = __( 'Restart Cache', 'varnish-http-purge' );
-				$vhp_add_query_arg   = array(
-					'vhp_flush_do'    => 'devmode',
-					'vhp_set_devmode' => 'dectivate',
-				);
-			} else {
-				$purge_devmode_title = __( 'Pause Cache (24h)', 'varnish-http-purge' );
-				$vhp_add_query_arg   = array(
-					'vhp_flush_do'    => 'devmode',
-					'vhp_set_devmode' => 'activate',
+			// If Devmode is in the config, don't allow it to be disabled.
+			if ( ! VHP_DEVMODE ) {
+				// Populate enable/disable cache button.
+				if ( VarnishDebug::devmode_check() ) {
+					$purge_devmode_title = __( 'Restart Cache', 'varnish-http-purge' );
+					$vhp_add_query_arg   = array(
+						'vhp_flush_do'    => 'devmode',
+						'vhp_set_devmode' => 'dectivate',
+					);
+				} else {
+					$purge_devmode_title = __( 'Pause Cache (24h)', 'varnish-http-purge' );
+					$vhp_add_query_arg   = array(
+						'vhp_flush_do'    => 'devmode',
+						'vhp_set_devmode' => 'activate',
+					);
+				}
+
+				$args[] = array(
+					'parent' => 'purge-varnish-cache',
+					'id'     => 'purge-varnish-cache-devmode',
+					'title'  => $purge_devmode_title,
+					'href'   => wp_nonce_url( add_query_arg( $vhp_add_query_arg ), 'vhp-flush-do' ),
+					'meta'   => array(
+						'title' => $purge_devmode_title,
+					),
 				);
 			}
-
-			$args[] = array(
-				'parent' => 'purge-varnish-cache',
-				'id'     => 'purge-varnish-cache-devmode',
-				'title'  => $purge_devmode_title,
-				'href'   => wp_nonce_url( add_query_arg( $vhp_add_query_arg ), 'vhp-flush-do' ),
-				'meta'   => array(
-					'title' => $purge_devmode_title,
-				),
-			);
 		}
 
 		if ( $can_purge ) {

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -91,6 +91,7 @@ class VarnishPurger {
 		add_action( 'init', array( &$this, 'init' ) );
 		add_action( 'admin_init', array( &$this, 'admin_init' ) );
 
+		// Check if there's an upgrade
 		add_action( 'upgrader_process_complete', array( &$this, 'check_upgrades' ), 10, 2 );
 
 	}
@@ -205,7 +206,9 @@ class VarnishPurger {
 	}
 
 	/**
-	 * Check if core has upgraded
+	 * Check if something has upgraded and try to flush the DB cache.
+	 * This runs for ALL upgrades (theme, plugin, and core) to account for
+	 * the complex nature that are upgrades.
 	 *
 	 * @param  array $object of upgrade data
 	 * @param  array $options picked for upgrade
@@ -213,7 +216,7 @@ class VarnishPurger {
 	 * @since 4.8
 	 */
 	public function check_upgrades( $object, $options ) {
-		if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) && 'core' === $options['type'] ) {
+		if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) ) {
 			wp_cache_flush();
 		}
 	}

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -513,15 +513,15 @@ class VarnishPurger {
 
 		// Define registered purge events.
 		$actions = array(
-			'autoptimize_action_cachepurged',  // Compat with https://wordpress.org/plugins/autoptimize/ plugin.
-			'delete_attachment',               // Delete an attachment - includes re-uploading.
-			'deleted_post',                    // Delete a post.
-			'edit_post',                       // Edit a post - includes leaving comments.
-			'import_start',                    // When importer starts
-			'import_end',                      // When importer ends
-			'save_post',                       // Save a post.
-			'switch_theme',                    // After a theme is changed.
-			'trashed_post',                    // Empty Trashed post.
+			'autoptimize_action_cachepurged', // Compat with https://wordpress.org/plugins/autoptimize/ plugin.
+			'delete_attachment',              // Delete an attachment - includes re-uploading.
+			'deleted_post',                   // Delete a post.
+			'edit_post',                      // Edit a post - includes leaving comments.
+			'import_start',                   // When importer starts
+			'import_end',                     // When importer ends
+			'save_post',                      // Save a post.
+			'switch_theme',                   // After a theme is changed.
+			'trashed_post',                   // Empty Trashed post.
 		);
 
 		// send back the actions array, filtered.
@@ -540,10 +540,10 @@ class VarnishPurger {
 
 		// Define registered purge events.
 		$actions = array(
-			'autoptimize_action_cachepurged,',  // Compat with https://wordpress.org/plugins/autoptimize/ plugin.
-			'import_start',                    // When importer starts
-			'import_end',                      // When importer ends
-			'switch_theme',                     // After a theme is changed.
+			'autoptimize_action_cachepurged', // Compat with https://wordpress.org/plugins/autoptimize/ plugin.
+			'import_start',                   // When importer starts
+			'import_end',                     // When importer ends
+			'switch_theme',                   // After a theme is changed.
 		);
 
 		/**

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -153,11 +153,11 @@ class VarnishPurger {
 		if ( VarnishDebug::devmode_check() ) {
 			if ( ! is_admin() ) {
 				// Sessions used to break PHP caching.
-				if ( ! is_user_logged_in() ) {
-					// @codingStandardsIgnoreStart
+				// @codingStandardsIgnoreStart
+				if ( ! is_user_logged_in() && session_status() != PHP_SESSION_ACTIVE ) {
 					@session_start();
-					// @codingStandardsIgnoreEnd
 				}
+				// @codingStandardsIgnoreEnd
 
 				// Add nocacche to CSS and JS.
 				add_filter( 'style_loader_src', array( 'VarnishDebug', 'nocache_cssjs' ), 10, 2 );

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -226,7 +226,7 @@ class VarnishPurger {
 	 * @since 4.8
 	 */
 	public function import_start() {
-		VarnishDebug::devmode_toggle( 'pause' );
+		VarnishDebug::devmode_toggle( 'activate' );
 	}
 
 	/**

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WP_CLI_Varnish_Command' ) ) {
 		 */
 		public function devmode( $args, $assoc_args ) {
 
-			$valid_modes = array( 'activate', 'deactivate', 'toggle', 'pause' );
+			$valid_modes = array( 'activate', 'deactivate', 'toggle' );
 			$devmode     = get_site_option( 'vhp_varnish_devmode', VarnishPurger::$devmode );
 
 			// Check for valid arguments.

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -135,7 +135,7 @@ if ( ! class_exists( 'WP_CLI_Varnish_Command' ) ) {
 		 */
 		public function devmode( $args, $assoc_args ) {
 
-			$valid_modes = array( 'activate', 'deactivate', 'toggle' );
+			$valid_modes = array( 'activate', 'deactivate', 'toggle', 'pause' );
 			$devmode     = get_site_option( 'vhp_varnish_devmode', VarnishPurger::$devmode );
 
 			// Check for valid arguments.
@@ -226,7 +226,9 @@ if ( ! class_exists( 'WP_CLI_Varnish_Command' ) ) {
 						escapeshellarg( $path ),
 						substr_count( ABSPATH, '/' ) + 1
 					);
+					// @codingStandardsIgnoreStart
 					system( $cmd );
+					// @codingStandardsIgnoreEnd
 				}
 				WP_CLI::log( '' );
 				WP_CLI::log( __( 'Grep complete. If no data was output, you\'re good!', 'varnish-http-purge' ) );

--- a/wp-cli.php
+++ b/wp-cli.php
@@ -260,7 +260,12 @@ if ( ! class_exists( 'WP_CLI_Varnish_Command' ) ) {
 
 			// Get the response and headers.
 			$remote_get = VarnishDebug::remote_get( $varnishurl );
-			$headers    = wp_remote_retrieve_headers( $remote_get );
+
+			if ( is_wp_error( $remote_get ) || 'fail' === $remote_get ) {
+				WP_CLI::error( __( 'Unable to retrieve data. Debug cannot be run at this time. Please run "curl -I [URL]" manually on your personal computer.', 'varnish-http-purge' ) );
+			}
+
+			$headers = wp_remote_retrieve_headers( $remote_get );
 
 			if ( WP_CLI\Utils\get_flag_value( $assoc_args, 'include-headers' ) ) {
 				WP_CLI::log( 'Headers:' );


### PR DESCRIPTION
Improvements based on feedback from TechSupport and users.

The main goal of this release is to make memcached stick less, and to process imports better. Hopefully this will help WooCommerce.

**Fixes:**
* Sanity check on debugger to be faster
* LINTer fixes
* Attempting to detect if Memcached type caches are stuck following DB updates, and flush cache if possible
* Better catch for wp-cli timeouts.


**New Feature:**
* If a WordPress importer is running, the caching will pause _AND_ empty  at the end.