### PR TITLE
Fix db version condition

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -145,7 +145,7 @@ class VarnishPurger {
 		// If the DB version we detect isn't the same as the version core thinks
 		// we will fush DB cache. This may cause double dumping in some cases but
 		// should not be harmful.
-		if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) && get_option( 'db_version' ) !== $wp_db_version ) {
+		if ( file_exists( WP_CONTENT_DIR . '/object-cache.php' ) && (int) get_option( 'db_version' ) !== $wp_db_version ) {
 			wp_cache_flush();
 		}
 


### PR DESCRIPTION
Environment:
Plugin version: 4.8
WordPress version: 5.1.1
Using object caching

It was recently brought to my attention that the object cache was constantly receiving flush calls. Disabling Varnish HTTP Purge did stop that behaviour.

After some investigating I found a condition testing for the DB version that kept returning `false` even though the DB version is up to date.

`get_option( 'db_version' ) !== $wp_db_version` turns out `get_option` returns a `string` and `$wp_db_version` is a `int`