### PR TITLE
Remove strtotime check on Age header

### DIFF
--- a/debug.php
+++ b/debug.php
@@ -599,11 +599,6 @@ class VarnishDebug {
 				'message' => sprintf( __( 'The "Age" header is returning %s, which means it is not properly caching. Either this URL is intentionally excluded from caching, or a theme or plugin is instructing WordPress not to cache.', 'varnish-http-purge' ), $age_header ),
 				'icon'    => 'warning',
 			);
-		} elseif ( (bool) strtotime( $headers['Age'] ) && time() <= strtotime( $headers['Age'] ) ) {
-			$return['Age Headers'] = array(
-				'icon'    => 'bad',
-				'message' => __( 'The "Age" header is set to an invalid time, which will result in incorrect caching.', 'varnish-http-purge' ),
-			);
 		} else {
 			$return['Age Headers'] = array(
 				'icon'    => 'awesome',

--- a/health-check.php
+++ b/health-check.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Health Check Code
+ * @package varnish-http-purge
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die();
+}
+
+// Health Check Test
+add_filter( 'site_status_tests', 'vhp_add_site_status_tests' );
+
+function vhp_add_site_status_tests( $tests ) {
+	$tests['direct']['proxy_cache_purge_caching'] = array(
+		'label' => __( 'Proxy Cache Purge Status', 'varnish-http-purge' ),
+		'test'  => 'vhp_site_status_caching_test',
+	);
+	return $tests;
+}
+
+function vhp_site_status_caching_test() {
+	$result = array(
+		'label'       => __( 'Proxy Cache Purge is working', 'varnish-http-purge' ),
+		'status'      => 'good',
+		'badge'       => array(
+			'label' => __( 'Performance', 'varnish-http-purge' ),
+			'color' => 'blue',
+		),
+		'description' => sprintf(
+			'<p>%s</p>',
+			__( 'Caching can help load your site more quickly for visitors. You\'re doing great!', 'varnish-http-purge' )
+		),
+		'actions'     => sprintf(
+			'<p><a href="%s">%s</a></p>',
+			esc_url( admin_url( 'admin.php?page=varnish-check-caching' ) ),
+			__( 'Check Caching Status', 'varnish-http-purge' )
+		),
+		'test'        => 'caching_plugin',
+	);
+
+	// If we're in dev mode....
+	if ( VarnishDebug::devmode_check() ) {
+		$result['status']      = 'recommended';
+		$result['label']       = __( 'Proxy Cache Purge is in development mode' );
+		$result['description'] = sprintf(
+			'<p>%s</p>',
+			__( 'Proxy Cache Purge is active but in dev mode, which means it will not serve cached content to your users. If this is intentional, carry on. Otherwise you should enable caching.', 'varnish-http-purge' )
+		);
+		$result['actions']     = sprintf(
+			'<p><a href="%s">%s</a></p>',
+			esc_url( admin_url( 'admin.php?page=varnish-page' ) ),
+			__( 'Enable Caching' )
+		);
+	}
+
+	return $result;
+}

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: Ipstenu, mikeschroder, techpriester, danielbachhuber
 Tags: proxy, purge, cache, varnish, nginx
 Requires at least: 4.7
 Tested up to: 5.2
-Stable tag: 4.8.1
-Requires PHP: 5.6
+Stable tag: 4.9
+Requires PHP: 7.0
 
 Automatically empty proxy cached content when your site is modified.
 
@@ -202,6 +202,10 @@ Yes _IF_ the service has an interface. Sadly Nginx does not. [Detailed direction
 This plugin is installed by default for _all_ DreamPress installs on DreamHost, and I maintain it for DreamHost, but it was not originally an official DreamHost plugin which means I will continue to support all users to the best of my ability.
 
 == Changelog ==
+
+= 4.9 =
+* MONTH 2019
+* Support for health check
 
 = 4.8.1 =
 * May 2019

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: Ipstenu, mikeschroder, techpriester, danielbachhuber
 Tags: proxy, purge, cache, varnish, nginx
 Requires at least: 4.7
-Tested up to: 5.2
+Tested up to: 5.4
 Stable tag: 4.9
 Requires PHP: 7.0
 

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -3,7 +3,7 @@
  * Plugin Name: Proxy Cache Purge
  * Plugin URI: https://halfelf.org/plugins/varnish-http-purge/
  * Description: Automatically empty cached pages when content on your site is modified.
- * Version: 4.8.1
+ * Version: 4.9
  * Author: Mika Epstein
  * Author URI: https://halfelf.org/
  * License: http://www.apache.org/licenses/LICENSE-2.0
@@ -35,7 +35,7 @@ class VarnishPurger {
 	 * Version Number
 	 * @var string
 	 */
-	public static $version = '4.8.1';
+	public static $version = '4.9';
 
 	/**
 	 * List of URLs to be purged
@@ -95,7 +95,6 @@ class VarnishPurger {
 
 		// Check if there's an upgrade
 		add_action( 'upgrader_process_complete', array( &$this, 'check_upgrades' ), 10, 2 );
-
 	}
 
 	/**
@@ -105,6 +104,7 @@ class VarnishPurger {
 	 * @access public
 	 */
 	public function admin_init() {
+		global $pagenow;
 
 		// If WordPress.com Master Bar is active, show the activity box.
 		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'masterbar' ) ) {
@@ -119,7 +119,7 @@ class VarnishPurger {
 		}
 
 		// Admin notices.
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( 'manage_options' ) && 'site-health.php' !== $pagenow ) {
 
 			// Warning: Debug is active.
 			if ( VarnishDebug::devmode_check() ) {
@@ -1004,5 +1004,6 @@ if ( ! is_network_admin() ) {
 	require_once 'settings.php';
 }
 require_once 'debug.php';
+require_once 'health-check.php';
 
 $purger = new VarnishPurger();

--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -533,6 +533,7 @@ class VarnishPurger {
 			'import_end',                     // When importer ends
 			'save_post',                      // Save a post.
 			'switch_theme',                   // After a theme is changed.
+			'customize_save_after',           // After Customizer is updated.
 			'trashed_post',                   // Empty Trashed post.
 		);
 
@@ -556,6 +557,7 @@ class VarnishPurger {
 			'import_start',                   // When importer starts
 			'import_end',                     // When importer ends
 			'switch_theme',                   // After a theme is changed.
+			'customize_save_after',           // After Customizer is updated.
 		);
 
 		/**


### PR DESCRIPTION
Since the `Age` header is a non-negative integer, when the value is passed into the `strtotime` function the values emitted are either invalid or unintended. 

Examples:
```
var_dump(strtotime("56")); # false
var_dump(strtotime("1056")); # 1592902560 (2020-06-23 10:56:00)
```

Both `56` and `1056` are perfectly valid values for the `Age` header, yet the plugin debug page will always show a warning that they are invalid because the output of the `strtotime` function is less than the current `time()`. 

Since there is already a check in place to ensure that the value passed in the header is a non-negative integer, this check can safely be removed. 