### PR TITLE
Fix fetching from site_option rather than option

### DIFF
--- a/varnish-http-purge.php
+++ b/varnish-http-purge.php
@@ -604,7 +604,7 @@ class VarnishPurger {
 			if ( defined( 'VHP_VARNISH_MAXPOSTS' ) && false !== VHP_VARNISH_MAXPOSTS ) {
 				$max_posts = VHP_VARNISH_MAXPOSTS;
 			} else {
-				$max_posts = get_option( 'vhp_varnish_max_posts_before_all' );
+				$max_posts = get_site_option( 'vhp_varnish_max_posts_before_all' );
 			}
 
 			// If there are more than vhp_varnish_max_posts_before_all URLs to purge (default 50),


### PR DESCRIPTION
The option "vhp_varnish_max_posts_before_all" is by default set via set_site_option but it is fetched via "get_option"

On multisites, this will always be empty, and we end up invalidating all cache on each post update in the multisite, since max_posts always will be lower than the countet urls.